### PR TITLE
Fix behaviour when environment argument not provided

### DIFF
--- a/ssh_ipykernel/kernel.py
+++ b/ssh_ipykernel/kernel.py
@@ -257,8 +257,8 @@ class SshKernel:
         # Build remote command
         sudo = "sudo " if self.sudo else ""
 
-        if self.env is not None:
-            env = " ".join(self.env)
+        env = " ".join(self.env) if self.env is not None else ""
+
         cmd = "{sudo} {env} {python} -m ipykernel_launcher -f {fname}".format(
             sudo=sudo, env=env, python=self.python_full_path, fname=self.fname
         )

--- a/ssh_ipykernel/manage.py
+++ b/ssh_ipykernel/manage.py
@@ -125,6 +125,8 @@ if __name__ == "__main__":
 
     if args.env:
         env = " ".join(args.env)
+    else:
+        env = None
 
     add_kernel(
         host=args.host,


### PR DESCRIPTION
If a kernel is defined without environment variables then `env` can be referenced while not set.
Set it explicitly to avoid errors and allow the remote kernel to be started.