### PR TITLE
Add support for connecting to Windows remotes.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.3
+current_version = 1.3.0-rc0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\-{0,1}(?P<release>\D*)(?P<build>\d*)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The ideas are heavily based on [remote_ikernel](https://bitbucket.org/tdaff/remo
 * Local ports (obtained by jupyter also via `write_connection_file`) will be ssh forwarded to the remote ports
 * The ssh connection and the tunnel command will be retried in case of network or similar errors
 * introduced signal handling with python's `signal` module
+* supports connecting to kernels running on Windows machines
 
 ## Installation
 
@@ -36,6 +37,8 @@ jupyter labextension install interrupt-ipykernel-extension
                           environment variables for the remote kernel in the
                           form: VAR1=value1 VAR2=value2
     -s                    sudo required to start kernel on the remote machine
+    --windows, -w         remote is windows
+
 
   required arguments:
     --file FILE, -f FILE  jupyter kernel connection file
@@ -73,9 +76,7 @@ jupyter labextension install interrupt-ipykernel-extension
     ```bash
     $ python -m ssh_ipykernel.manage --help
 
-    usage: manage.py [--help] [--display-name DISPLAY_NAME] [--sudo]
-                    [--timeout TIMEOUT] [--env [ENV [ENV ...]]] --host HOST
-                    --python PYTHON
+    usage: manage.py [--help] [--display-name DISPLAY_NAME] [--sudo] [--timeout TIMEOUT] [--env [ENV ...]] [--windows] --host HOST --python PYTHON
 
     optional arguments:
       --help, -h            show this help message and exit
@@ -84,9 +85,9 @@ jupyter labextension install interrupt-ipykernel-extension
       --sudo, -s            sudo required to start kernel on the remote machine
       --timeout TIMEOUT, -t TIMEOUT
                             timeout for remote commands
-      --env [ENV [ENV ...]], -e [ENV [ENV ...]]
-                            environment variables for the remote kernel in the
-                            form: VAR1=value1 VAR2=value2
+      --env [ENV ...], -e [ENV ...]
+                            environment variables for the remote kernel in the form: VAR1=value1 VAR2=value2
+      --windows, -w         remote is windows
 
     required arguments:
       --host HOST, -H HOST  remote host

--- a/README.md
+++ b/README.md
@@ -26,19 +26,16 @@ jupyter labextension install interrupt-ipykernel-extension
 
   ```text
   $ python -m ssh_ipykernel -h
-  usage: __main__.py [--help] [--timeout TIMEOUT] [--env [ENV [ENV ...]]] [-s]
-                    --file FILE --host HOST --python PYTHON
+  usage: __main__.py [--help] [--timeout TIMEOUT] [--env [ENV ...]] [-s] [--windows] --file FILE --host HOST --python PYTHON
 
   optional arguments:
     --help, -h            show this help message and exit
     --timeout TIMEOUT, -t TIMEOUT
                           timeout for remote commands
-    --env [ENV [ENV ...]], -e [ENV [ENV ...]]
-                          environment variables for the remote kernel in the
-                          form: VAR1=value1 VAR2=value2
+    --env [ENV ...], -e [ENV ...]
+                          environment variables for the remote kernel in the form: VAR1=value1 VAR2=value2
     -s                    sudo required to start kernel on the remote machine
     --windows, -w         remote is windows
-
 
   required arguments:
     --file FILE, -f FILE  jupyter kernel connection file

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,6 @@ setup(
     packages=find_packages(exclude=["ssh_ipykernel_interrupt"]),
     python_requires=">=3.5",
     url="https://github.com/bernhard-42/ssh_ipykernel",
-    version="1.2.3",
+    version="1.3.0-rc0",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,9 @@ setup(
     ],
     description="A remote jupyter ipykernel via ssh",
     install_requires=[
-        "tornado>=6.1.0,<=6.2.0",
-        "jupyter_client>=6.1.12,<6.2.0",
-        "jupyterlab>=3.0.0,<3.1.0",
+        "tornado>=6.1.0",
+        "jupyter_client>=6.1.12",
+        "jupyterlab>=3.0.0",
         "wexpect==3.3.2;platform_system=='Windows'",
         "pexpect==4.8.0;platform_system!='Windows'",
         "ssh_ipykernel_interrupt==1.1.2",

--- a/ssh_ipykernel/__main__.py
+++ b/ssh_ipykernel/__main__.py
@@ -4,7 +4,7 @@ import sys
 from .kernel import SshKernel
 
 
-def main(host, connection_info, python_path, sudo, timeout, env):
+def main(host, connection_info, python_path, sudo, timeout, env, is_windows):
     """Main function to be called as module to create SshKernel
 
     Arguments:
@@ -14,8 +14,10 @@ def main(host, connection_info, python_path, sudo, timeout, env):
         sudo {bool} -- Start ipykernel as root if necessary (default: {False})
         timeout {int} -- SSH connection timeout (default: {5})
         env {str} -- Environment variables passd to the ipykernel "VAR1=VAL1 VAR2=VAL2" (default: {""})
+        is_windows {bool} -- Indicates that the target system is Windows.
     """
-    kernel = SshKernel(host, connection_info, python_path, sudo, timeout, env)
+    print("II is_windows: " + str(is_windows))
+    kernel = SshKernel(host, connection_info, python_path, sudo, timeout, env, is_windows=is_windows)
     try:
         kernel.create_remote_connection_info()
         kernel.start_kernel_and_tunnels()
@@ -46,12 +48,14 @@ if __name__ == "__main__":
     optional.add_argument(
         "-s", action="store_true", help="sudo required to start kernel on the remote machine"
     )
+    optional.add_argument("--windows", "-w", action="store_true", help="remote is windows")
 
     required = parser.add_argument_group("required arguments")
     required.add_argument("--file", "-f", required=True, help="jupyter kernel connection file")
     required.add_argument("--host", "-H", required=True, help="remote host")
     required.add_argument("--python", "-p", required=True, help="remote python_path")
     args = parser.parse_args()
+    print(args)
 
     try:
         with open(args.file, "r") as fd:
@@ -60,4 +64,4 @@ if __name__ == "__main__":
         print(ex)
         sys.exit(1)
 
-    sys.exit(main(args.host, connection_info, args.python, args.s, args.timeout, args.env))
+    sys.exit(main(args.host, connection_info, args.python, args.s, args.timeout, args.env, is_windows=args.windows))

--- a/ssh_ipykernel/__main__.py
+++ b/ssh_ipykernel/__main__.py
@@ -16,7 +16,6 @@ def main(host, connection_info, python_path, sudo, timeout, env, is_windows):
         env {str} -- Environment variables passd to the ipykernel "VAR1=VAL1 VAR2=VAL2" (default: {""})
         is_windows {bool} -- Indicates that the target system is Windows.
     """
-    print("II is_windows: " + str(is_windows))
     kernel = SshKernel(host, connection_info, python_path, sudo, timeout, env, is_windows=is_windows)
     try:
         kernel.create_remote_connection_info()
@@ -55,7 +54,6 @@ if __name__ == "__main__":
     required.add_argument("--host", "-H", required=True, help="remote host")
     required.add_argument("--python", "-p", required=True, help="remote python_path")
     args = parser.parse_args()
-    print(args)
 
     try:
         with open(args.file, "r") as fd:

--- a/ssh_ipykernel/_version.py
+++ b/ssh_ipykernel/_version.py
@@ -12,5 +12,5 @@ def get_version(version):
     return VersionInfo(major, minor, patch, release, build)
 
 
-__version__ = "1.2.3"  # DO NOT EDIT THIS DIRECTLY!  It is managed by bumpversion
+__version__ = "1.3.0-rc0"  # DO NOT EDIT THIS DIRECTLY!  It is managed by bumpversion
 __version_info__ = get_version(__version__)

--- a/ssh_ipykernel/kernel.py
+++ b/ssh_ipykernel/kernel.py
@@ -88,7 +88,6 @@ class SshKernel:
         logger=None,
         is_windows=False,
     ):
-        print("is windows: " + str(is_windows))
         self.host = host
         self.connection_info = connection_info
         if is_windows:
@@ -159,11 +158,9 @@ class SshKernel:
         self._logger.info("Creating remote connection info")
         script = KERNEL_SCRIPT.format(fname=self.fname, **self.connection_info)
 
-
         cmd = "{python} -c \"{command}\"".format(
             python=self.python_full_path, command=("; ".join(script.strip().split("\n")).replace("\"", "\\\""))
         )
-        print(cmd)
 
         result = self._ssh(cmd)
         self._logger.debug(result)

--- a/ssh_ipykernel/manage.py
+++ b/ssh_ipykernel/manage.py
@@ -21,6 +21,7 @@ def add_kernel(
     timeout=5,
     module="ssh_ipykernel",
     opt_args=None,
+    is_windows=False,
 ):
     """Add a new kernel specification for an SSH Kernel
 
@@ -29,6 +30,7 @@ def add_kernel(
         display_name {str} -- Display name for the new kernel
         local_python_path {[type]} -- Local python path to be used (without bin/python)
         remote_python_path {[type]} -- Remote python path to be used (without bin/python)
+        is_windows {bool} -- Indicates that the remote is Windows.
 
     Keyword Arguments:
         env {str} -- Environment variables passd to the ipykernel "VAR1=VAL1 VAR2=VAL2" (default: {""})
@@ -68,6 +70,9 @@ def add_kernel(
         "display_name": display_name,
         "language": "python",
     }
+    if is_windows:
+        kernel_json["argv"].insert(-2, "--windows")
+
     if env is not None:
         kernel_json["argv"].insert(-2, "--env")
         kernel_json["argv"].insert(-2, env)
@@ -117,6 +122,7 @@ if __name__ == "__main__":
         nargs="*",
         help="environment variables for the remote kernel in the form: VAR1=value1 VAR2=value2",
     )
+    optional.add_argument("--windows", "-w", action="store_true", help="remote is windows")
 
     required = parser.add_argument_group("required arguments")
     required.add_argument("--host", "-H", required=True, help="remote host")
@@ -134,4 +140,5 @@ if __name__ == "__main__":
         sudo=args.sudo,
         env=env,
         timeout=args.timeout,
+        is_windows=args.windows,
     )


### PR DESCRIPTION
I added a support for remote kernels running on Windows machines. 

It can be turned on by simple adding `--windows` command line switch. 

I also removed the upper bounds on versions for the dependencies. I don't think there is anything that will break with newer versions and it complicates the install at the moment. It might be a good idea to add them back only when there is a known problem.