### PR TITLE
Fix exception when the --env argument was missing.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.3
+current_version = 1.2.4-rc0
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\-{0,1}(?P<release>\D*)(?P<build>\d*)

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,6 @@ setup(
     packages=find_packages(exclude=["ssh_ipykernel_interrupt"]),
     python_requires=">=3.5",
     url="https://github.com/bernhard-42/ssh_ipykernel",
-    version="1.2.3",
+    version="1.2.4-rc0",
     zip_safe=False,
 )

--- a/ssh_ipykernel/_version.py
+++ b/ssh_ipykernel/_version.py
@@ -12,5 +12,5 @@ def get_version(version):
     return VersionInfo(major, minor, patch, release, build)
 
 
-__version__ = "1.2.3"  # DO NOT EDIT THIS DIRECTLY!  It is managed by bumpversion
+__version__ = "1.2.4-rc0"  # DO NOT EDIT THIS DIRECTLY!  It is managed by bumpversion
 __version_info__ = get_version(__version__)

--- a/ssh_ipykernel/manage.py
+++ b/ssh_ipykernel/manage.py
@@ -123,8 +123,7 @@ if __name__ == "__main__":
     required.add_argument("--python", "-p", required=True, help="remote python_path")
     args = parser.parse_args()
 
-    if args.env:
-        env = " ".join(args.env)
+    env = " ".join(args.env if args.env else [])
 
     add_kernel(
         host=args.host,


### PR DESCRIPTION
Fixing this bug: https://github.com/bernhard-42/ssh_ipykernel/issues/24